### PR TITLE
Bug fix

### DIFF
--- a/mayaTools/cgm/core/mrs/lib/scene_utils.py
+++ b/mayaTools/cgm/core/mrs/lib/scene_utils.py
@@ -28,10 +28,11 @@ logging.basicConfig()
 log = logging.getLogger(__name__)
 log.setLevel(logging.DEBUG)
 #========================================================================
-__version__ = cgmGEN.__RELEASE
 
 import maya.cmds as mc
 from cgm.core import cgm_General as cgmGEN
+__version__ = cgmGEN.__RELEASE
+
 
 from cgm.core.cgmPy import path_Utils as PATH
 import cgm.core.cgmPy.os_Utils as CGMOS


### PR DESCRIPTION
`__version__ = cgmGEN.__RELEASE` was incorrectly placed and was preventing the toolset from working.

I have moved this to be after the import call `from cgm.core import cgm_General as cgmGEN`

This is now working for me.
And also testing out a more secure way to collaborate :-)


